### PR TITLE
feat: use buffered channels in ForeachChannel

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,27 +164,27 @@ Few ECS tools exist for Go. Arche and unitoftime/ecs are probably the most looke
 In the benchmark folder, this module is compared to both of them.
 
 - Go - v1.23.1
-- Volt - v1.0.0
+- Volt - v1.1.0
 - [Arche - v0.13.2](https://github.com/mlange-42/arche)
 - [UECS - v0.0.2-0.20240727195554-03fbb2d998cf](https://github.com/unitoftime/ecs)
 
 The given results were produced by a ryzen 7 5800x, with 100.000 entities:
 
-| Benchmark feature (entities count)                                | Time/Operation | Bytes/Operation  | Allocations/Operation |
-|-------------------------------------------------------------------|----------------|------------------|-----------------------|
-| BenchmarkCreateEntityVolt (100000)                                | 28019814 ns/op | 27509201 B/op    | 203267 allocs/op      |
-| BenchmarkCreateEntityArche (100000)                               | 13090540 ns/op | 43679965 B/op    | 1631 allocs/op        |
-| BenchmarkCreateEntityUECS (100000)                                | 33813923 ns/op | 49120107 B/op    | 200148 allocs/op      |
-| BenchmarkIterateVolt (100000)                                     | 327920 ns/op   | 128 B/op         | 5 allocs/op           |
-| BenchmarkIterateConcurrentlyVolt (100000) - 16 concurrent workers | 130565 ns/op   | 3092 B/op        | 90 allocs/op          |
-| BenchmarkIterateArche (100000)                                    | 302350 ns/op   | 354 B/op         | 4 allocs/op           |
-| BenchmarkIterateUECS (100000)                                     | 234814 ns/op   | 152 B/op         | 4 allocs/op           |
-| BenchmarkAddVolt (100000)                                         | 27868065 ns/op | 4750176 B/op     | 300002 allocs/op      |
-| BenchmarkAddArche (100000)                                        | 6204147 ns/op  | 3329050 B/op     | 200000 allocs/op      |
-| BenchmarkAddUECS (100000)                                         | 71806194 ns/op | 16643870 B/op    | 500010 allocs/op      |
-| BenchmarkRemoveVolt (100000)                                      | 19352594 ns/op | 200000 B/op      | 100000 allocs/op      |
-| BenchmarkRemoveArche (100000)                                     | 6796755 ns/op  | 3300006 B/op     | 200000 allocs/op      |
-| BenchmarkRemoveUECS (100000)                                      | 76231994 ns/op | 17092955 B/op    | 600002 allocs/op      |
+| Benchmark feature (entities count)                                | Time/Operation  | Bytes/Operation | Allocations/Operation |
+|-------------------------------------------------------------------|-----------------|-----------------|-----------------------|
+| BenchmarkCreateEntityVolt (100000)                                | 28019814 ns/op  | 27509201 B/op   | 203267 allocs/op      |
+| BenchmarkCreateEntityArche (100000)                               | 13090540 ns/op  | 43679965 B/op   | 1631 allocs/op        |
+| BenchmarkCreateEntityUECS (100000)                                | 33813923 ns/op  | 49120107 B/op   | 200148 allocs/op      |
+| BenchmarkIterateVolt (100000)                                     | 327920 ns/op    | 128 B/op        | 5 allocs/op           |
+| BenchmarkIterateConcurrentlyVolt (100000) - 16 concurrent workers | 95396 ns/op     | 3274 B/op       | 93 allocs/op          |
+| BenchmarkIterateArche (100000)                                    | 302350 ns/op    | 354 B/op        | 4 allocs/op           |
+| BenchmarkIterateUECS (100000)                                     | 234814 ns/op    | 152 B/op        | 4 allocs/op           |
+| BenchmarkAddVolt (100000)                                         | 27868065 ns/op  | 4750176 B/op    | 300002 allocs/op      |
+| BenchmarkAddArche (100000)                                        | 6204147 ns/op   | 3329050 B/op    | 200000 allocs/op      |
+| BenchmarkAddUECS (100000)                                         | 71806194 ns/op  | 16643870 B/op   | 500010 allocs/op      |
+| BenchmarkRemoveVolt (100000)                                      | 19352594 ns/op  | 200000 B/op     | 100000 allocs/op      |
+| BenchmarkRemoveArche (100000)                                     | 6796755 ns/op   | 3300006 B/op    | 200000 allocs/op      |
+| BenchmarkRemoveUECS (100000)                                      | 76231994 ns/op  | 17092955 B/op   | 600002 allocs/op      |
 
 These results show a few things:
 - Arche is the fastest tool for writes operations. In our game development though we would rather lean towards fastest read operations, because the games loops will read way more often than write.

--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -3,9 +3,11 @@ module benchmark
 go 1.23.0
 
 require (
-	github.com/akmonengine/volt v1.0.1
+	github.com/akmonengine/volt v1.0.3
 	github.com/mlange-42/arche v0.13.2
 	github.com/unitoftime/ecs v0.0.2-0.20240727195554-03fbb2d998cf
 )
 
 require github.com/unitoftime/cod v0.0.0-20230616173404-085cf4fe3918 // indirect
+
+replace github.com/akmonengine/volt v1.0.3 => ./../../volt

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,5 +1,3 @@
-github.com/akmonengine/volt v1.0.1 h1:mNc+gYvqMDwBa3rqivqg9i9VwZi+QnhZ09k69Da2ScM=
-github.com/akmonengine/volt v1.0.1/go.mod h1:rc4czDixWYc4kPd/oOMuz8TulJnX6KS5V1c7AVbTkGI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mlange-42/arche v0.13.2 h1:5mbYKYBTLrXkz33IEONBskRfpWmnLF6HAt3r+zPlSCI=

--- a/query.go
+++ b/query.go
@@ -2,6 +2,7 @@ package volt
 
 import (
 	"iter"
+	"math"
 	"slices"
 )
 
@@ -104,7 +105,8 @@ func (query *Query1[A]) ForeachChannel(chunkSize int, filterFn func(QueryResult1
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult1[A]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult1[A]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -254,7 +256,8 @@ func (query *Query2[A, B]) ForeachChannel(chunkSize int, filterFn func(QueryResu
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult2[A, B]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult2[A, B]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -427,7 +430,8 @@ func (query *Query3[A, B, C]) ForeachChannel(chunkSize int, filterFn func(QueryR
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult3[A, B, C]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult3[A, B, C]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -620,7 +624,8 @@ func (query *Query4[A, B, C, D]) ForeachChannel(chunkSize int, filterFn func(Que
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult4[A, B, C, D]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult4[A, B, C, D]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -828,7 +833,8 @@ func (query *Query5[A, B, C, D, E]) ForeachChannel(chunkSize int, filterFn func(
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult5[A, B, C, D, E]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult5[A, B, C, D, E]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -1054,7 +1060,8 @@ func (query *Query6[A, B, C, D, E, F]) ForeachChannel(chunkSize int, filterFn fu
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult6[A, B, C, D, E, F]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult6[A, B, C, D, E, F]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -1298,7 +1305,8 @@ func (query *Query7[A, B, C, D, E, F, G]) ForeachChannel(chunkSize int, filterFn
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult7[A, B, C, D, E, F, G]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult7[A, B, C, D, E, F, G]], int(channelsCount))
 
 	go func() {
 		defer close(channel)
@@ -1559,7 +1567,8 @@ func (query *Query8[A, B, C, D, E, F, G, H]) ForeachChannel(chunkSize int, filte
 		panic("chunk size must be greater than zero")
 	}
 
-	channel := make(chan iter.Seq[QueryResult8[A, B, C, D, E, F, G, H]])
+	channelsCount := math.Ceil(float64(query.Count()) / float64(chunkSize))
+	channel := make(chan iter.Seq[QueryResult8[A, B, C, D, E, F, G, H]], int(channelsCount))
 
 	go func() {
 		defer close(channel)


### PR DESCRIPTION
The buffered channels is computed using query.Count / chunkSize

This allows to get +30% performances, at the expense of memory usage and additional allocations