### PR TITLE
feat: change types from public to private

### DIFF
--- a/archetype.go
+++ b/archetype.go
@@ -4,9 +4,9 @@ import (
 	"slices"
 )
 
-func (world *World) createArchetype(componentsIds ...ComponentId) *Archetype {
-	archetypeKey := ArchetypeId(len(world.archetypes))
-	archetype := Archetype{
+func (world *World) createArchetype(componentsIds ...ComponentId) *archetype {
+	archetypeKey := archetypeId(len(world.archetypes))
+	archetype := archetype{
 		Id:   archetypeKey,
 		Type: componentsIds,
 	}
@@ -15,7 +15,7 @@ func (world *World) createArchetype(componentsIds ...ComponentId) *Archetype {
 	return &world.archetypes[archetypeKey]
 }
 
-func (world *World) getArchetype(entityRecord EntityRecord) *Archetype {
+func (world *World) getArchetype(entityRecord entityRecord) *archetype {
 	archetypeId := entityRecord.archetypeId
 
 	if int(archetypeId) >= len(world.archetypes) {
@@ -25,15 +25,15 @@ func (world *World) getArchetype(entityRecord EntityRecord) *Archetype {
 	return &world.archetypes[archetypeId]
 }
 
-func (world *World) setArchetype(entityRecord EntityRecord, archetype *Archetype) {
+func (world *World) setArchetype(entityRecord entityRecord, archetype *archetype) {
 	archetype.entities = append(archetype.entities, entityRecord.Id)
 
 	entityRecord.key = len(archetype.entities) - 1
 	entityRecord.archetypeId = archetype.Id
-	world.Entities[entityRecord.Id] = entityRecord
+	world.entities[entityRecord.Id] = entityRecord
 }
 
-func (world *World) getArchetypeForComponentsIds(componentsIds ...ComponentId) *Archetype {
+func (world *World) getArchetypeForComponentsIds(componentsIds ...ComponentId) *archetype {
 	for i, archetype := range world.archetypes {
 		if len(archetype.Type) != len(componentsIds) {
 			continue
@@ -56,8 +56,8 @@ func (world *World) getArchetypeForComponentsIds(componentsIds ...ComponentId) *
 	return world.createArchetype(componentsIds...)
 }
 
-func (world *World) getArchetypesForComponentsIds(componentsIds ...ComponentId) []Archetype {
-	var archetypes []Archetype
+func (world *World) getArchetypesForComponentsIds(componentsIds ...ComponentId) []archetype {
+	var archetypes []archetype
 
 	for _, archetype := range world.archetypes {
 		i := 0
@@ -75,9 +75,9 @@ func (world *World) getArchetypesForComponentsIds(componentsIds ...ComponentId) 
 	return archetypes
 }
 
-func (world *World) getNextArchetype(entityId EntityId, componentsIds ...ComponentId) *Archetype {
-	var archetype *Archetype
-	if entityRecord, ok := world.Entities[entityId]; !ok {
+func (world *World) getNextArchetype(entityId EntityId, componentsIds ...ComponentId) *archetype {
+	var archetype *archetype
+	if entityRecord, ok := world.entities[entityId]; !ok {
 		archetype = world.getArchetypeForComponentsIds(componentsIds...)
 	} else {
 		oldArchetype := world.getArchetype(entityRecord)

--- a/component.go
+++ b/component.go
@@ -27,7 +27,7 @@ func (world *World) getComponentsIds(components ...ComponentInterface) []Compone
 // The parameter conf contains all the data required for the configuration.
 func ConfigureComponent[T ComponentInterface](world *World, conf any) T {
 	var t T
-	componentRegistry := world.ComponentsRegistry[t.GetComponentId()]
+	componentRegistry := world.componentsRegistry[t.GetComponentId()]
 
 	componentRegistry.builderFn(&t, conf)
 
@@ -65,7 +65,7 @@ func AddComponent[T ComponentInterface](world *World, entityId EntityId, compone
 func AddComponents2[A, B ComponentInterface](world *World, entityId EntityId, a A, b B) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -95,7 +95,7 @@ func AddComponents2[A, B ComponentInterface](world *World, entityId EntityId, a 
 func AddComponents3[A, B, C ComponentInterface](world *World, entityId EntityId, a A, b B, c C) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -126,7 +126,7 @@ func AddComponents3[A, B, C ComponentInterface](world *World, entityId EntityId,
 func AddComponents4[A, B, C, D ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -158,7 +158,7 @@ func AddComponents4[A, B, C, D ComponentInterface](world *World, entityId Entity
 func AddComponents5[A, B, C, D, E ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -191,7 +191,7 @@ func AddComponents5[A, B, C, D, E ComponentInterface](world *World, entityId Ent
 func AddComponents6[A, B, C, D, E, F ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E, f F) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -225,7 +225,7 @@ func AddComponents6[A, B, C, D, E, F ComponentInterface](world *World, entityId 
 func AddComponents7[A, B, C, D, E, F, G ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E, f F, g G) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -260,7 +260,7 @@ func AddComponents7[A, B, C, D, E, F, G ComponentInterface](world *World, entity
 func AddComponents8[A, B, C, D, E, F, G, H ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E, f F, g G, h H) error {
 	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId())
 
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
@@ -317,7 +317,7 @@ func (world *World) AddComponent(entityId EntityId, componentId ComponentId, con
 func RemoveComponent[T ComponentInterface](world *World, entityId EntityId) error {
 	var t T
 	componentId := t.GetComponentId()
-	entityRecord := world.Entities[entityId]
+	entityRecord := world.entities[entityId]
 
 	if !world.hasComponents(entityRecord, componentId) {
 		return fmt.Errorf("the entity %d doesn't own the component %d", entityId, componentId)
@@ -337,7 +337,7 @@ func RemoveComponent[T ComponentInterface](world *World, entityId EntityId) erro
 //   - the entity does not have the component
 //   - the ComponentId is not registered in the World
 func (world *World) RemoveComponent(entityId EntityId, componentId ComponentId) error {
-	entityRecord := world.Entities[entityId]
+	entityRecord := world.entities[entityId]
 
 	if !world.hasComponents(entityRecord, componentId) {
 		return fmt.Errorf("the entity %d doesn't own the component %d", entityId, componentId)
@@ -354,7 +354,7 @@ func (world *World) RemoveComponent(entityId EntityId, componentId ComponentId) 
 	return nil
 }
 
-func removeComponent(world *World, s storage, entityRecord EntityRecord, componentId ComponentId) {
+func removeComponent(world *World, s storage, entityRecord entityRecord, componentId ComponentId) {
 	world.componentRemovedFn(entityRecord.Id, componentId)
 
 	oldArchetype := &world.archetypes[entityRecord.archetypeId]
@@ -377,7 +377,7 @@ func removeComponent(world *World, s storage, entityRecord EntityRecord, compone
 //
 // It returns false if at least one ComponentId is not owned.
 func (world *World) HasComponents(entityId EntityId, componentsIds ...ComponentId) bool {
-	entityRecord, ok := world.Entities[entityId]
+	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return false
 	}
@@ -385,7 +385,7 @@ func (world *World) HasComponents(entityId EntityId, componentsIds ...ComponentI
 	return world.hasComponents(entityRecord, componentsIds...)
 }
 
-func (world *World) hasComponents(entityRecord EntityRecord, componentsIds ...ComponentId) bool {
+func (world *World) hasComponents(entityRecord entityRecord, componentsIds ...ComponentId) bool {
 	archetype := world.archetypes[entityRecord.archetypeId]
 	for _, componentId := range componentsIds {
 		if !slices.Contains(archetype.Type, componentId) {
@@ -401,7 +401,7 @@ func (world *World) hasComponents(entityRecord EntityRecord, componentsIds ...Co
 // If the entity does not have the component, it returns nil
 func GetComponent[T ComponentInterface](world *World, entityId EntityId) *T {
 	s := getStorage[T](world)
-	entityRecord := world.Entities[entityId]
+	entityRecord := world.entities[entityId]
 
 	if !s.hasArchetype(entityRecord.archetypeId) {
 		return nil
@@ -418,7 +418,7 @@ func GetComponent[T ComponentInterface](world *World, entityId EntityId) *T {
 //   - the ComponentId is not registered in the World
 //   - the entity does not have the component
 func (world *World) GetComponent(entityId EntityId, componentId ComponentId) (any, error) {
-	entityRecord := world.Entities[entityId]
+	entityRecord := world.entities[entityId]
 	s, err := world.getStorageForComponentId(componentId)
 	if err != nil {
 		return nil, err
@@ -431,7 +431,7 @@ func (world *World) GetComponent(entityId EntityId, componentId ComponentId) (an
 	return s.get(entityRecord.archetypeId, entityRecord.key), nil
 }
 
-func addComponentsToArchetype1[A ComponentInterface](world *World, entityId EntityId, archetype *Archetype, component A) error {
+func addComponentsToArchetype1[A ComponentInterface](world *World, entityId EntityId, archetype *archetype, component A) error {
 	storageA := getStorage[A](world)
 
 	if storageA == nil {
@@ -440,7 +440,7 @@ func addComponentsToArchetype1[A ComponentInterface](world *World, entityId Enti
 	}
 
 	// If the entity has no component, simply add it the archetype
-	if entityRecord, ok := world.Entities[entityId]; !ok {
+	if entityRecord, ok := world.entities[entityId]; !ok {
 		world.setArchetype(entityRecord, archetype)
 		setComponent(world, archetype.Id, component)
 	} else {
@@ -456,7 +456,7 @@ func addComponentsToArchetype1[A ComponentInterface](world *World, entityId Enti
 	return nil
 }
 
-func addComponentsToArchetype2[A, B ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B) error {
+func addComponentsToArchetype2[A, B ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 
@@ -472,7 +472,7 @@ func addComponentsToArchetype2[A, B ComponentInterface](world *World, entityReco
 	return nil
 }
 
-func addComponentsToArchetype3[A, B, C ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B, componentC C) error {
+func addComponentsToArchetype3[A, B, C ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B, componentC C) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 	storageC := getStorage[C](world)
@@ -490,7 +490,7 @@ func addComponentsToArchetype3[A, B, C ComponentInterface](world *World, entityR
 	return nil
 }
 
-func addComponentsToArchetype4[A, B, C, D ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B, componentC C, componentD D) error {
+func addComponentsToArchetype4[A, B, C, D ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B, componentC C, componentD D) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 	storageC := getStorage[C](world)
@@ -510,7 +510,7 @@ func addComponentsToArchetype4[A, B, C, D ComponentInterface](world *World, enti
 	return nil
 }
 
-func addComponentsToArchetype5[A, B, C, D, E ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B, componentC C, componentD D, componentE E) error {
+func addComponentsToArchetype5[A, B, C, D, E ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B, componentC C, componentD D, componentE E) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 	storageC := getStorage[C](world)
@@ -532,7 +532,7 @@ func addComponentsToArchetype5[A, B, C, D, E ComponentInterface](world *World, e
 	return nil
 }
 
-func addComponentsToArchetype6[A, B, C, D, E, F ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B, componentC C, componentD D, componentE E, componentF F) error {
+func addComponentsToArchetype6[A, B, C, D, E, F ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B, componentC C, componentD D, componentE E, componentF F) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 	storageC := getStorage[C](world)
@@ -556,7 +556,7 @@ func addComponentsToArchetype6[A, B, C, D, E, F ComponentInterface](world *World
 	return nil
 }
 
-func addComponentsToArchetype7[A, B, C, D, E, F, G ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B, componentC C, componentD D, componentE E, componentF F, componentG G) error {
+func addComponentsToArchetype7[A, B, C, D, E, F, G ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B, componentC C, componentD D, componentE E, componentF F, componentG G) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 	storageC := getStorage[C](world)
@@ -582,7 +582,7 @@ func addComponentsToArchetype7[A, B, C, D, E, F, G ComponentInterface](world *Wo
 	return nil
 }
 
-func addComponentsToArchetype8[A, B, C, D, E, F, G, H ComponentInterface](world *World, entityRecord EntityRecord, archetype *Archetype, componentA A, componentB B, componentC C, componentD D, componentE E, componentF F, componentG G, componentH H) error {
+func addComponentsToArchetype8[A, B, C, D, E, F, G, H ComponentInterface](world *World, entityRecord entityRecord, archetype *archetype, componentA A, componentB B, componentC C, componentD D, componentE E, componentF F, componentG G, componentH H) error {
 	storageA := getStorage[A](world)
 	storageB := getStorage[B](world)
 	storageC := getStorage[C](world)
@@ -610,7 +610,7 @@ func addComponentsToArchetype8[A, B, C, D, E, F, G, H ComponentInterface](world 
 	return nil
 }
 
-func moveComponentsToArchetype(world *World, entityRecord EntityRecord, oldArchetype *Archetype, archetype *Archetype) int {
+func moveComponentsToArchetype(world *World, entityRecord entityRecord, oldArchetype *archetype, archetype *archetype) int {
 	var key, lastEntityKey int
 
 	for _, componentId := range oldArchetype.Type {
@@ -629,9 +629,9 @@ func moveComponentsToArchetype(world *World, entityRecord EntityRecord, oldArche
 	lastEntityKey = len(oldArchetype.entities) - 1
 
 	lastEntityId := oldArchetype.entities[lastEntityKey]
-	lastEntity := world.Entities[lastEntityId]
+	lastEntity := world.entities[lastEntityId]
 	lastEntity.key = entityRecord.key
-	world.Entities[lastEntityId] = lastEntity
+	world.entities[lastEntityId] = lastEntity
 
 	oldArchetype.entities[entityRecord.key] = lastEntityId
 	oldArchetype.entities = oldArchetype.entities[:lastEntityKey]
@@ -639,7 +639,7 @@ func moveComponentsToArchetype(world *World, entityRecord EntityRecord, oldArche
 	return key
 }
 
-func setComponent[T ComponentInterface](world *World, archetypeId ArchetypeId, component T) int {
+func setComponent[T ComponentInterface](world *World, archetypeId archetypeId, component T) int {
 	s := getStorage[T](world)
 
 	return s.add(archetypeId, component)

--- a/query.go
+++ b/query.go
@@ -22,7 +22,7 @@ type QueryResult1[A ComponentInterface] struct {
 	A        *A
 }
 
-type QueryResultChunk1[A ComponentInterface] struct {
+type queryResultChunk1[A ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 }
@@ -41,7 +41,7 @@ func (query *Query1[A]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query1[A]) filter() []Archetype {
+func (query *Query1[A]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -132,7 +132,7 @@ func (query *Query1[A]) ForeachChannel(chunkSize int, filterFn func(QueryResult1
 			sliceA := storageA.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk1[A]{}
+				result := queryResultChunk1[A]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -181,7 +181,7 @@ type QueryResult2[A, B ComponentInterface] struct {
 	B        *B
 }
 
-type QueryResultChunk2[A, B ComponentInterface] struct {
+type queryResultChunk2[A, B ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -202,7 +202,7 @@ func (query *Query2[A, B]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query2[A, B]) filter() []Archetype {
+func (query *Query2[A, B]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -298,7 +298,7 @@ func (query *Query2[A, B]) ForeachChannel(chunkSize int, filterFn func(QueryResu
 			sliceB := storageB.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk2[A, B]{}
+				result := queryResultChunk2[A, B]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -354,7 +354,7 @@ type QueryResult3[A, B, C ComponentInterface] struct {
 	C        *C
 }
 
-type QueryResultChunk3[A, B, C ComponentInterface] struct {
+type queryResultChunk3[A, B, C ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -377,7 +377,7 @@ func (query *Query3[A, B, C]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query3[A, B, C]) filter() []Archetype {
+func (query *Query3[A, B, C]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -487,7 +487,7 @@ func (query *Query3[A, B, C]) ForeachChannel(chunkSize int, filterFn func(QueryR
 			sliceC := storageC.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk3[A, B, C]{}
+				result := queryResultChunk3[A, B, C]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -550,7 +550,7 @@ type QueryResult4[A, B, C, D ComponentInterface] struct {
 	D        *D
 }
 
-type QueryResultChunk4[A, B, C, D ComponentInterface] struct {
+type queryResultChunk4[A, B, C, D ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -575,7 +575,7 @@ func (query *Query4[A, B, C, D]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query4[A, B, C, D]) filter() []Archetype {
+func (query *Query4[A, B, C, D]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -694,7 +694,7 @@ func (query *Query4[A, B, C, D]) ForeachChannel(chunkSize int, filterFn func(Que
 			sliceD := storageD.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk4[A, B, C, D]{}
+				result := queryResultChunk4[A, B, C, D]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -763,7 +763,7 @@ type QueryResult5[A, B, C, D, E ComponentInterface] struct {
 	E        *E
 }
 
-type QueryResultChunk5[A, B, C, D, E ComponentInterface] struct {
+type queryResultChunk5[A, B, C, D, E ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -790,7 +790,7 @@ func (query *Query5[A, B, C, D, E]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query5[A, B, C, D, E]) filter() []Archetype {
+func (query *Query5[A, B, C, D, E]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -918,7 +918,7 @@ func (query *Query5[A, B, C, D, E]) ForeachChannel(chunkSize int, filterFn func(
 			sliceE := storageE.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk5[A, B, C, D, E]{}
+				result := queryResultChunk5[A, B, C, D, E]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -995,7 +995,7 @@ type QueryResult6[A, B, C, D, E, F ComponentInterface] struct {
 	F        *F
 }
 
-type QueryResultChunk6[A, B, C, D, E, F ComponentInterface] struct {
+type queryResultChunk6[A, B, C, D, E, F ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -1023,7 +1023,7 @@ func (query *Query6[A, B, C, D, E, F]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query6[A, B, C, D, E, F]) filter() []Archetype {
+func (query *Query6[A, B, C, D, E, F]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -1160,7 +1160,7 @@ func (query *Query6[A, B, C, D, E, F]) ForeachChannel(chunkSize int, filterFn fu
 			sliceF := storageF.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk6[A, B, C, D, E, F]{}
+				result := queryResultChunk6[A, B, C, D, E, F]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -1244,7 +1244,7 @@ type QueryResult7[A, B, C, D, E, F, G ComponentInterface] struct {
 	G        *G
 }
 
-type QueryResultChunk7[A, B, C, D, E, F, G ComponentInterface] struct {
+type queryResultChunk7[A, B, C, D, E, F, G ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -1274,7 +1274,7 @@ func (query *Query7[A, B, C, D, E, F, G]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query7[A, B, C, D, E, F, G]) filter() []Archetype {
+func (query *Query7[A, B, C, D, E, F, G]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -1420,7 +1420,7 @@ func (query *Query7[A, B, C, D, E, F, G]) ForeachChannel(chunkSize int, filterFn
 			sliceG := storageG.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk7[A, B, C, D, E, F, G]{}
+				result := queryResultChunk7[A, B, C, D, E, F, G]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does
@@ -1511,7 +1511,7 @@ type QueryResult8[A, B, C, D, E, F, G, H ComponentInterface] struct {
 	H        *H
 }
 
-type QueryResultChunk8[A, B, C, D, E, F, G, H ComponentInterface] struct {
+type queryResultChunk8[A, B, C, D, E, F, G, H ComponentInterface] struct {
 	EntityId []EntityId
 	A        []A
 	B        []B
@@ -1543,7 +1543,7 @@ func (query *Query8[A, B, C, D, E, F, G, H]) GetComponentsIds() []ComponentId {
 	return query.componentsIds
 }
 
-func (query *Query8[A, B, C, D, E, F, G, H]) filter() []Archetype {
+func (query *Query8[A, B, C, D, E, F, G, H]) filter() []archetype {
 	var componentsIds []ComponentId
 
 	for _, componentId := range query.componentsIds {
@@ -1697,7 +1697,7 @@ func (query *Query8[A, B, C, D, E, F, G, H]) ForeachChannel(chunkSize int, filte
 			sliceH := storageH.archetypesComponentsEntities[archetype.Id]
 
 			for i := 0; i < len(archetype.entities); i += chunkSize {
-				result := QueryResultChunk8[A, B, C, D, E, F, G, H]{}
+				result := queryResultChunk8[A, B, C, D, E, F, G, H]{}
 				end := min(chunkSize, len(archetype.entities[i:]))
 
 				// Set the capacity of each chunk so that appending to a chunk does

--- a/register.go
+++ b/register.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+// ComponentConfigInterface is the interface
+// defining the method required to create a new Component.
 type ComponentConfigInterface interface {
 	builderFn(component any, configuration any)
 	getComponentId() ComponentId
@@ -57,17 +59,17 @@ type ComponentBuilder func(component any, configuration any)
 // Once the component is registered, it can be added to an entity.
 func RegisterComponent[T ComponentInterface](world *World, config ComponentConfigInterface) {
 	var t T
-	if world.ComponentsRegistry == nil {
-		world.ComponentsRegistry = make(ComponentsRegister)
+	if world.componentsRegistry == nil {
+		world.componentsRegistry = make(ComponentsRegister)
 	}
 
 	config.setComponent(t)
-	world.ComponentsRegistry[t.GetComponentId()] = config
+	world.componentsRegistry[t.GetComponentId()] = config
 	getStorage[T](world)
 }
 
 func (world *World) getConfigByComponentId(componentId ComponentId) (ComponentConfigInterface, error) {
-	for _, config := range world.ComponentsRegistry {
+	for _, config := range world.componentsRegistry {
 		if config.getComponentId() == componentId {
 			return config, nil
 		}

--- a/storage.go
+++ b/storage.go
@@ -10,7 +10,7 @@ func getStorage[T ComponentInterface](world *World) *ComponentsStorage[T] {
 	var t T
 	componentId := t.GetComponentId()
 
-	if _, ok := world.ComponentsRegistry[componentId]; !ok {
+	if _, ok := world.componentsRegistry[componentId]; !ok {
 		return nil
 	}
 
@@ -37,18 +37,18 @@ func (world *World) getStorageForComponentId(componentId ComponentId) (storage, 
 
 type storage interface {
 	getType() ComponentId
-	getArchetypes() []ArchetypeId
-	hasArchetype(archetypeId ArchetypeId) bool
-	add(archetypeId ArchetypeId, component ComponentInterface) int
-	set(archetypeId ArchetypeId, key int, component ComponentInterface)
-	get(archetypeId ArchetypeId, key int) any
-	copy(oldArchetypeId ArchetypeId, archetypeId ArchetypeId, recordKey int) int
-	size(archetypeId ArchetypeId) int
-	moveLastToKey(archetypeId ArchetypeId, recordKey int)
-	delete(archetypeId ArchetypeId, key int)
+	getArchetypes() []archetypeId
+	hasArchetype(archetypeId archetypeId) bool
+	add(archetypeId archetypeId, component ComponentInterface) int
+	set(archetypeId archetypeId, key int, component ComponentInterface)
+	get(archetypeId archetypeId, key int) any
+	copy(oldArchetypeId archetypeId, archetypeId archetypeId, recordKey int) int
+	size(archetypeId archetypeId) int
+	moveLastToKey(archetypeId archetypeId, recordKey int)
+	delete(archetypeId archetypeId, key int)
 }
 
-type ArchetypesComponentsEntities[T ComponentInterface] map[ArchetypeId][]T
+type ArchetypesComponentsEntities[T ComponentInterface] map[archetypeId][]T
 
 type ComponentsStorage[T ComponentInterface] struct {
 	componentId                  ComponentId
@@ -59,11 +59,11 @@ func (c *ComponentsStorage[T]) getType() ComponentId {
 	return c.componentId
 }
 
-func (c *ComponentsStorage[T]) getArchetypes() []ArchetypeId {
+func (c *ComponentsStorage[T]) getArchetypes() []archetypeId {
 	return slices.Collect(maps.Keys(c.archetypesComponentsEntities))
 }
 
-func (c *ComponentsStorage[T]) hasArchetype(archetypeId ArchetypeId) bool {
+func (c *ComponentsStorage[T]) hasArchetype(archetypeId archetypeId) bool {
 	if _, ok := c.archetypesComponentsEntities[archetypeId]; !ok {
 		return false
 	}
@@ -71,11 +71,11 @@ func (c *ComponentsStorage[T]) hasArchetype(archetypeId ArchetypeId) bool {
 	return true
 }
 
-func (c *ComponentsStorage[T]) size(archetypeId ArchetypeId) int {
+func (c *ComponentsStorage[T]) size(archetypeId archetypeId) int {
 	return len(c.archetypesComponentsEntities[archetypeId])
 }
 
-func (c *ComponentsStorage[T]) add(archetypeId ArchetypeId, component ComponentInterface) int {
+func (c *ComponentsStorage[T]) add(archetypeId archetypeId, component ComponentInterface) int {
 	// this function could be simplified using:
 	// c.size(archetypeId) - 1
 	// but to reduce the usage of mapaccess we compute the size ourselves instead of calling c.size
@@ -86,19 +86,19 @@ func (c *ComponentsStorage[T]) add(archetypeId ArchetypeId, component ComponentI
 
 }
 
-func (c *ComponentsStorage[T]) copy(oldArchetypeId ArchetypeId, archetypeId ArchetypeId, recordKey int) int {
+func (c *ComponentsStorage[T]) copy(oldArchetypeId archetypeId, archetypeId archetypeId, recordKey int) int {
 	return c.add(archetypeId, c.archetypesComponentsEntities[oldArchetypeId][recordKey])
 }
 
-func (c *ComponentsStorage[T]) set(archetypeId ArchetypeId, key int, component ComponentInterface) {
+func (c *ComponentsStorage[T]) set(archetypeId archetypeId, key int, component ComponentInterface) {
 	c.archetypesComponentsEntities[archetypeId][key] = component.(T)
 }
 
-func (c *ComponentsStorage[T]) get(archetypeId ArchetypeId, key int) any {
+func (c *ComponentsStorage[T]) get(archetypeId archetypeId, key int) any {
 	return &c.archetypesComponentsEntities[archetypeId][key]
 }
 
-func (c *ComponentsStorage[T]) moveLastToKey(archetypeId ArchetypeId, recordKey int) {
+func (c *ComponentsStorage[T]) moveLastToKey(archetypeId archetypeId, recordKey int) {
 	// this function could be simplified using:
 	// 	lastKey := c.size(archetypeId) - 1
 	// 	c.set(archetypeId, recordKey, c.archetypesComponentsEntities[archetypeId][lastKey])
@@ -116,7 +116,7 @@ func (c *ComponentsStorage[T]) moveLastToKey(archetypeId ArchetypeId, recordKey 
 	}
 }
 
-func (c *ComponentsStorage[T]) delete(archetypeId ArchetypeId, key int) {
+func (c *ComponentsStorage[T]) delete(archetypeId archetypeId, key int) {
 	if key < c.size(archetypeId) {
 		data := c.archetypesComponentsEntities[archetypeId]
 		c.archetypesComponentsEntities[archetypeId] = append(data[:key], data[key+1:]...)

--- a/world.go
+++ b/world.go
@@ -11,47 +11,49 @@ import (
 type smallID uint8
 
 // uint64 identifier, for big scoped data.
-type ID uint64
+type id uint64
 
 // Entity identifier in the world.
-type EntityId ID
+type EntityId id
 
 // Component identifier in the register.
 type ComponentId smallID
 
-// Archetype identifier in the world.
-type ArchetypeId ID
+// archetype identifier in the world.
+type archetypeId id
 
-// List of Components required for an Archetype.
-type Type []ComponentId
+// List of ComponentId.
+type componentsIds []ComponentId
 
-type Archetype struct {
-	Id       ArchetypeId
-	Type     Type
+// Implementation of an archetype with its identifier, componentsIds, and entitiesIds
+type archetype struct {
+	Id       archetypeId
+	Type     componentsIds
 	entities []EntityId
 }
 
-type EntityRecord struct {
+// Container of archetype and key position in storage, for a given EntityId
+type entityRecord struct {
 	Id          EntityId
-	archetypeId ArchetypeId
+	archetypeId archetypeId
 	key         int
-	name        EntityName
+	name        entityName
 }
 
-// EntityName is a string transformed to byte array.
+// entityName is a string transformed to byte array.
 //
 // It avoids the garbage collector to analyze this data constantly,
 // at the price of a fixed data size.
-type EntityName [64]byte
-type EntitiesNames map[EntityName]EntityId
-type Entities map[EntityId]EntityRecord
+type entityName [64]byte
+type entitiesNames map[entityName]EntityId
+type entities map[EntityId]entityRecord
 
-// World representation, container of all the data related to Entities and their Components.
+// World representation, container of all the data related to entities and their Components.
 type World struct {
-	ComponentsRegistry ComponentsRegister
-	entitiesNames      EntitiesNames
-	Entities           Entities
-	archetypes         []Archetype
+	componentsRegistry ComponentsRegister
+	entitiesNames      entitiesNames
+	entities           entities
+	archetypes         []archetype
 	storage            []storage
 
 	entityAddedFn      func(entityId EntityId)
@@ -65,9 +67,9 @@ type World struct {
 // It preallocates initialCapacity in memory.
 func CreateWorld(initialCapacity int) *World {
 	world := &World{
-		entitiesNames:      make(EntitiesNames, initialCapacity),
-		Entities:           make(Entities, initialCapacity),
-		archetypes:         make([]Archetype, 0, 1024),
+		entitiesNames:      make(entitiesNames, initialCapacity),
+		entities:           make(entities, initialCapacity),
+		archetypes:         make([]archetype, 0, 1024),
 		storage:            make([]storage, 256),
 		entityAddedFn:      func(entityId EntityId) {},
 		entityRemovedFn:    func(entityId EntityId) {},
@@ -112,11 +114,11 @@ func (world *World) CreateEntity(name string) EntityId {
 	archetype := world.getArchetypeForComponentsIds()
 
 	world.entitiesNames[entityName] = entityId
-	entityRecord := EntityRecord{
+	entityRecord := entityRecord{
 		Id:   entityId,
 		name: entityName,
 	}
-	world.Entities[entityId] = entityRecord
+	world.entities[entityId] = entityRecord
 	world.setArchetype(entityRecord, archetype)
 
 	return entityId
@@ -129,7 +131,7 @@ func CreateEntityWithComponents2[A, B ComponentInterface](world *World, name str
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents2(world, entityId, a, b)
 	if err != nil {
@@ -147,7 +149,7 @@ func CreateEntityWithComponents3[A, B, C ComponentInterface](world *World, name 
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents3(world, entityId, a, b, c)
 	if err != nil {
@@ -165,7 +167,7 @@ func CreateEntityWithComponents4[A, B, C, D ComponentInterface](world *World, na
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents4(world, entityId, a, b, c, d)
 	if err != nil {
@@ -183,7 +185,7 @@ func CreateEntityWithComponents5[A, B, C, D, E ComponentInterface](world *World,
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents5(world, entityId, a, b, c, d, e)
 	if err != nil {
@@ -201,7 +203,7 @@ func CreateEntityWithComponents6[A, B, C, D, E, F ComponentInterface](world *Wor
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents6(world, entityId, a, b, c, d, e, f)
 	if err != nil {
@@ -219,7 +221,7 @@ func CreateEntityWithComponents7[A, B, C, D, E, F, G ComponentInterface](world *
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents7(world, entityId, a, b, c, d, e, f, g)
 	if err != nil {
@@ -237,7 +239,7 @@ func CreateEntityWithComponents8[A, B, C, D, E, F, G, H ComponentInterface](worl
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.Entities[entityId] = EntityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
 
 	err := AddComponents8(world, entityId, a, b, c, d, e, f, g, h)
 	if err != nil {
@@ -258,7 +260,7 @@ func (world *World) PublishEntity(entityId EntityId) {
 func (world *World) RemoveEntity(entityId EntityId) {
 	world.entityRemovedFn(entityId)
 
-	entityRecord := world.Entities[entityId]
+	entityRecord := world.entities[entityId]
 	archetype := world.archetypes[entityRecord.archetypeId]
 
 	lastEntityKey := len(archetype.entities) - 1
@@ -270,10 +272,10 @@ func (world *World) RemoveEntity(entityId EntityId) {
 
 	if lastEntityKey >= 0 {
 		lastEntityId := world.archetypes[archetype.Id].entities[lastEntityKey]
-		lastEntity := world.Entities[lastEntityId]
+		lastEntity := world.entities[lastEntityId]
 		if lastEntity.key > entityRecord.key {
 			lastEntity.key = entityRecord.key
-			world.Entities[lastEntityId] = lastEntity
+			world.entities[lastEntityId] = lastEntity
 			archetype.entities[entityRecord.key] = lastEntityId
 		}
 
@@ -281,8 +283,8 @@ func (world *World) RemoveEntity(entityId EntityId) {
 		world.archetypes[archetype.Id] = archetype
 	}
 
-	delete(world.entitiesNames, world.Entities[entityId].name)
-	delete(world.Entities, entityId)
+	delete(world.entitiesNames, world.entities[entityId].name)
+	delete(world.entities, entityId)
 }
 
 // SearchEntity returns the EntityId named by name.
@@ -299,7 +301,7 @@ func (world *World) SearchEntity(name string) EntityId {
 // GetEntityName returns the name of an EntityId.
 // If not found, returns an empty string.
 func (world *World) GetEntityName(entityId EntityId) string {
-	if entity, ok := world.Entities[entityId]; ok {
+	if entity, ok := world.entities[entityId]; ok {
 		return entityNameToString(entity.name)
 	}
 
@@ -310,19 +312,19 @@ func (world *World) GetEntityName(entityId EntityId) string {
 func (world *World) SetEntityName(entityId EntityId, name string) {
 	entityName := stringToEntityName(name)
 
-	entityRecord := world.Entities[entityId]
+	entityRecord := world.entities[entityId]
 	entityRecord.name = entityName
-	world.Entities[entityId] = entityRecord
+	world.entities[entityId] = entityRecord
 	world.entitiesNames[entityName] = entityId
 }
 
-func stringToEntityName(name string) EntityName {
-	var nameByte EntityName
+func stringToEntityName(name string) entityName {
+	var nameByte entityName
 	copy(nameByte[:], name)
 
 	return nameByte
 }
 
-func entityNameToString(entityName EntityName) string {
+func entityNameToString(entityName entityName) string {
 	return strings.TrimRight(string(entityName[:]), "\x00")
 }

--- a/world_test.go
+++ b/world_test.go
@@ -29,11 +29,11 @@ func TestWorld_CreateEntity(t *testing.T) {
 	}
 
 	// Check if the entities all exist in the world
-	if len(world.Entities) != TEST_ENTITY_NUMBER {
+	if len(world.entities) != TEST_ENTITY_NUMBER {
 		t.Errorf("Number of entities created invalid")
 	}
 	for i := 0; i < TEST_ENTITY_NUMBER; i++ {
-		_, ok := world.Entities[entities[i]]
+		_, ok := world.entities[entities[i]]
 
 		if !ok {
 			t.Errorf("Entity %d was not created properly", entities[i])
@@ -54,7 +54,7 @@ func TestCreateEntityWithComponents2(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -79,7 +79,7 @@ func TestCreateEntityWithComponents3(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -108,7 +108,7 @@ func TestCreateEntityWithComponents4(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -141,7 +141,7 @@ func TestCreateEntityWithComponents5(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -178,7 +178,7 @@ func TestCreateEntityWithComponents6(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -219,7 +219,7 @@ func TestCreateEntityWithComponents7(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -264,7 +264,7 @@ func TestCreateEntityWithComponents8(t *testing.T) {
 	if id := world.SearchEntity("entity1"); id == 0 {
 		t.Errorf("Could not find entityName %s", "entity1")
 	}
-	if _, ok := world.Entities[entityId]; !ok {
+	if _, ok := world.entities[entityId]; !ok {
 		t.Errorf("Could not find entityId %d", entityId)
 	}
 	if component := GetComponent[testComponent1](world, entityId); component == nil {
@@ -306,7 +306,7 @@ func TestWorld_RemoveEntity(t *testing.T) {
 	world.RemoveEntity(entities[TEST_ENTITY_NUMBER-1])
 
 	// Check the expected world size
-	if len(world.Entities) != (TEST_ENTITY_NUMBER - 3) {
+	if len(world.entities) != (TEST_ENTITY_NUMBER - 3) {
 		t.Errorf("World size not valid after removal of entities")
 	}
 


### PR DESCRIPTION
Some types should not be made public, they are meant to be used internally: archetype, archetypeId, entities, entitiesNames, entityName, entityRecord, id, componentsIds.
We also rename Type from componentsIds, to avoid using the Go keyword 'type'.

BREAKING CHANGE: those types being private are not available anymore. Though they were not documented as "usable" so it should not break any code.