### PR TITLE
Optimize entities creation, between 10 to 20% faster

### DIFF
--- a/component.go
+++ b/component.go
@@ -63,12 +63,19 @@ func AddComponent[T ComponentInterface](world *World, entityId EntityId, compone
 //
 // This solution is faster than an atomic solution.
 func AddComponents2[A, B ComponentInterface](world *World, entityId EntityId, a A, b B) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents2(world, entityRecord, a, b)
+}
+
+func addComponents2[A, B ComponentInterface](world *World, entityRecord entityRecord, a A, b B) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId()})
 	}
@@ -93,19 +100,26 @@ func AddComponents2[A, B ComponentInterface](world *World, entityId EntityId, a 
 //
 // This solution is faster than an atomic solution.
 func AddComponents3[A, B, C ComponentInterface](world *World, entityId EntityId, a A, b B, c C) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents3(world, entityRecord, a, b, c)
+}
+
+func addComponents3[A, B, C ComponentInterface](world *World, entityRecord entityRecord, a A, b B, c C) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId(), c.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId()})
 	}
 
 	err := addComponentsToArchetype3(world, entityRecord, archetype, a, b, c)
 	if err != nil {
-		return fmt.Errorf("the components %v cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId()}, entityId, err)
+		return fmt.Errorf("the components %d cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId()}, entityId, err)
 	}
 
 	world.componentAddedFn(entityId, a.GetComponentId())
@@ -124,19 +138,26 @@ func AddComponents3[A, B, C ComponentInterface](world *World, entityId EntityId,
 //
 // This solution is faster than an atomic solution.
 func AddComponents4[A, B, C, D ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents4(world, entityRecord, a, b, c, d)
+}
+
+func addComponents4[A, B, C, D ComponentInterface](world *World, entityRecord entityRecord, a A, b B, c C, d D) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId()})
 	}
 
 	err := addComponentsToArchetype4(world, entityRecord, archetype, a, b, c, d)
 	if err != nil {
-		return fmt.Errorf("the components %v cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId()}, entityId, err)
+		return fmt.Errorf("the components %d cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId()}, entityId, err)
 	}
 
 	world.componentAddedFn(entityId, a.GetComponentId())
@@ -156,19 +177,26 @@ func AddComponents4[A, B, C, D ComponentInterface](world *World, entityId Entity
 //
 // This solution is faster than an atomic solution.
 func AddComponents5[A, B, C, D, E ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents5(world, entityRecord, a, b, c, d, e)
+}
+
+func addComponents5[A, B, C, D, E ComponentInterface](world *World, entityRecord entityRecord, a A, b B, c C, d D, e E) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId()})
 	}
 
 	err := addComponentsToArchetype5(world, entityRecord, archetype, a, b, c, d, e)
 	if err != nil {
-		return fmt.Errorf("the components %v cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId()}, entityId, err)
+		return fmt.Errorf("the components %d cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId()}, entityId, err)
 	}
 
 	world.componentAddedFn(entityId, a.GetComponentId())
@@ -189,19 +217,26 @@ func AddComponents5[A, B, C, D, E ComponentInterface](world *World, entityId Ent
 //
 // This solution is faster than an atomic solution.
 func AddComponents6[A, B, C, D, E, F ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E, f F) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents6(world, entityRecord, a, b, c, d, e, f)
+}
+
+func addComponents6[A, B, C, D, E, F ComponentInterface](world *World, entityRecord entityRecord, a A, b B, c C, d D, e E, f F) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId()})
 	}
 
 	err := addComponentsToArchetype6(world, entityRecord, archetype, a, b, c, d, e, f)
 	if err != nil {
-		return fmt.Errorf("the components %v cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId()}, entityId, err)
+		return fmt.Errorf("the components %d cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId()}, entityId, err)
 	}
 
 	world.componentAddedFn(entityId, a.GetComponentId())
@@ -223,19 +258,26 @@ func AddComponents6[A, B, C, D, E, F ComponentInterface](world *World, entityId 
 //
 // This solution is faster than an atomic solution.
 func AddComponents7[A, B, C, D, E, F, G ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E, f F, g G) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents7(world, entityRecord, a, b, c, d, e, f, g)
+}
+
+func addComponents7[A, B, C, D, E, F, G ComponentInterface](world *World, entityRecord entityRecord, a A, b B, c C, d D, e E, f F, g G) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId()})
 	}
 
 	err := addComponentsToArchetype7(world, entityRecord, archetype, a, b, c, d, e, f, g)
 	if err != nil {
-		return fmt.Errorf("the components %v cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId()}, entityId, err)
+		return fmt.Errorf("the components %d cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId()}, entityId, err)
 	}
 
 	world.componentAddedFn(entityId, a.GetComponentId())
@@ -258,19 +300,26 @@ func AddComponents7[A, B, C, D, E, F, G ComponentInterface](world *World, entity
 //
 // This solution is faster than an atomic solution.
 func AddComponents8[A, B, C, D, E, F, G, H ComponentInterface](world *World, entityId EntityId, a A, b B, c C, d D, e E, f F, g G, h H) error {
-	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId())
-
 	entityRecord, ok := world.entities[entityId]
 	if !ok {
 		return fmt.Errorf("entity %v does not exist", entityId)
 	}
+
+	return addComponents8(world, entityRecord, a, b, c, d, e, f, g, h)
+}
+
+func addComponents8[A, B, C, D, E, F, G, H ComponentInterface](world *World, entityRecord entityRecord, a A, b B, c C, d D, e E, f F, g G, h H) error {
+	archetype := world.getArchetypeForComponentsIds(a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId())
+
+	entityId := entityRecord.Id
+
 	if world.hasComponents(entityRecord, a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId()) {
 		return fmt.Errorf("the entity %d already owns the components %v", entityId, []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId()})
 	}
 
 	err := addComponentsToArchetype8(world, entityRecord, archetype, a, b, c, d, e, f, g, h)
 	if err != nil {
-		return fmt.Errorf("the components %v cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId()}, entityId, err)
+		return fmt.Errorf("the components %d cannot be added to entity %d: %w", []ComponentId{a.GetComponentId(), b.GetComponentId(), c.GetComponentId(), d.GetComponentId(), e.GetComponentId(), f.GetComponentId(), g.GetComponentId(), h.GetComponentId()}, entityId, err)
 	}
 
 	world.componentAddedFn(entityId, a.GetComponentId())

--- a/component.go
+++ b/component.go
@@ -491,7 +491,7 @@ func addComponentsToArchetype1[A ComponentInterface](world *World, entityId Enti
 	// If the entity has no component, simply add it the archetype
 	if entityRecord, ok := world.entities[entityId]; !ok {
 		world.setArchetype(entityRecord, archetype)
-		setComponent(world, archetype.Id, component)
+		storageA.add(archetype.Id, component)
 	} else {
 		oldArchetype := world.getArchetype(entityRecord)
 		if archetype.Id != oldArchetype.Id {
@@ -499,7 +499,7 @@ func addComponentsToArchetype1[A ComponentInterface](world *World, entityId Enti
 			world.setArchetype(entityRecord, archetype)
 		}
 
-		setComponent(world, archetype.Id, component)
+		storageA.add(archetype.Id, component)
 	}
 
 	return nil
@@ -514,8 +514,8 @@ func addComponentsToArchetype2[A, B ComponentInterface](world *World, entityReco
 		return fmt.Errorf("no storage found for component %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -531,9 +531,9 @@ func addComponentsToArchetype3[A, B, C ComponentInterface](world *World, entityR
 		return fmt.Errorf("no storage found for components %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
-	setComponent(world, archetype.Id, componentC)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
+	storageC.add(archetype.Id, componentC)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -550,10 +550,10 @@ func addComponentsToArchetype4[A, B, C, D ComponentInterface](world *World, enti
 		return fmt.Errorf("no storage found for components %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
-	setComponent(world, archetype.Id, componentC)
-	setComponent(world, archetype.Id, componentD)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
+	storageC.add(archetype.Id, componentC)
+	storageD.add(archetype.Id, componentD)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -571,11 +571,11 @@ func addComponentsToArchetype5[A, B, C, D, E ComponentInterface](world *World, e
 		return fmt.Errorf("no storage found for components %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
-	setComponent(world, archetype.Id, componentC)
-	setComponent(world, archetype.Id, componentD)
-	setComponent(world, archetype.Id, componentE)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
+	storageC.add(archetype.Id, componentC)
+	storageD.add(archetype.Id, componentD)
+	storageE.add(archetype.Id, componentE)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -594,12 +594,12 @@ func addComponentsToArchetype6[A, B, C, D, E, F ComponentInterface](world *World
 		return fmt.Errorf("no storage found for components %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
-	setComponent(world, archetype.Id, componentC)
-	setComponent(world, archetype.Id, componentD)
-	setComponent(world, archetype.Id, componentE)
-	setComponent(world, archetype.Id, componentF)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
+	storageC.add(archetype.Id, componentC)
+	storageD.add(archetype.Id, componentD)
+	storageE.add(archetype.Id, componentE)
+	storageF.add(archetype.Id, componentF)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -619,13 +619,13 @@ func addComponentsToArchetype7[A, B, C, D, E, F, G ComponentInterface](world *Wo
 		return fmt.Errorf("no storage found for components %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
-	setComponent(world, archetype.Id, componentC)
-	setComponent(world, archetype.Id, componentD)
-	setComponent(world, archetype.Id, componentE)
-	setComponent(world, archetype.Id, componentF)
-	setComponent(world, archetype.Id, componentG)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
+	storageC.add(archetype.Id, componentC)
+	storageD.add(archetype.Id, componentD)
+	storageE.add(archetype.Id, componentE)
+	storageF.add(archetype.Id, componentF)
+	storageG.add(archetype.Id, componentG)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -646,14 +646,14 @@ func addComponentsToArchetype8[A, B, C, D, E, F, G, H ComponentInterface](world 
 		return fmt.Errorf("no storage found for components %v", componentsIds)
 	}
 
-	setComponent(world, archetype.Id, componentA)
-	setComponent(world, archetype.Id, componentB)
-	setComponent(world, archetype.Id, componentC)
-	setComponent(world, archetype.Id, componentD)
-	setComponent(world, archetype.Id, componentE)
-	setComponent(world, archetype.Id, componentF)
-	setComponent(world, archetype.Id, componentG)
-	setComponent(world, archetype.Id, componentH)
+	storageA.add(archetype.Id, componentA)
+	storageB.add(archetype.Id, componentB)
+	storageC.add(archetype.Id, componentC)
+	storageD.add(archetype.Id, componentD)
+	storageE.add(archetype.Id, componentE)
+	storageF.add(archetype.Id, componentF)
+	storageG.add(archetype.Id, componentG)
+	storageH.add(archetype.Id, componentH)
 	world.setArchetype(entityRecord, archetype)
 
 	return nil
@@ -686,10 +686,4 @@ func moveComponentsToArchetype(world *World, entityRecord entityRecord, oldArche
 	oldArchetype.entities = oldArchetype.entities[:lastEntityKey]
 
 	return key
-}
-
-func setComponent[T ComponentInterface](world *World, archetypeId archetypeId, component T) int {
-	s := getStorage[T](world)
-
-	return s.add(archetypeId, component)
 }

--- a/world.go
+++ b/world.go
@@ -131,9 +131,10 @@ func CreateEntityWithComponents2[A, B ComponentInterface](world *World, name str
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents2(world, entityId, a, b)
+	err := addComponents2(world, entityRecord, a, b)
 	if err != nil {
 		return 0, err
 	}
@@ -149,9 +150,10 @@ func CreateEntityWithComponents3[A, B, C ComponentInterface](world *World, name 
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents3(world, entityId, a, b, c)
+	err := addComponents3(world, entityRecord, a, b, c)
 	if err != nil {
 		return 0, err
 	}
@@ -167,9 +169,10 @@ func CreateEntityWithComponents4[A, B, C, D ComponentInterface](world *World, na
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents4(world, entityId, a, b, c, d)
+	err := addComponents4(world, entityRecord, a, b, c, d)
 	if err != nil {
 		return 0, err
 	}
@@ -185,9 +188,10 @@ func CreateEntityWithComponents5[A, B, C, D, E ComponentInterface](world *World,
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents5(world, entityId, a, b, c, d, e)
+	err := addComponents5(world, entityRecord, a, b, c, d, e)
 	if err != nil {
 		return 0, err
 	}
@@ -203,9 +207,10 @@ func CreateEntityWithComponents6[A, B, C, D, E, F ComponentInterface](world *Wor
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents6(world, entityId, a, b, c, d, e, f)
+	err := addComponents6(world, entityRecord, a, b, c, d, e, f)
 	if err != nil {
 		return 0, err
 	}
@@ -221,9 +226,10 @@ func CreateEntityWithComponents7[A, B, C, D, E, F, G ComponentInterface](world *
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents7(world, entityId, a, b, c, d, e, f, g)
+	err := addComponents7(world, entityRecord, a, b, c, d, e, f, g)
 	if err != nil {
 		return 0, err
 	}
@@ -239,9 +245,10 @@ func CreateEntityWithComponents8[A, B, C, D, E, F, G, H ComponentInterface](worl
 	entityId := newEntityId()
 
 	world.entitiesNames[entityName] = entityId
-	world.entities[entityId] = entityRecord{Id: entityId, name: entityName}
+	entityRecord := entityRecord{Id: entityId, name: entityName}
+	world.entities[entityId] = entityRecord
 
-	err := AddComponents8(world, entityId, a, b, c, d, e, f, g, h)
+	err := addComponents8(world, entityRecord, a, b, c, d, e, f, g, h)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Reducing the map access to EntityRecords, we can improve the performances up to ~10% the creation of entities with CreateEntityWithComponentsN.

We can also reduce the number of calls to getStorage when calling addComponentsToArchetype, improving around ~10% again.