### PR TITLE
Use the Archetype's components in RemoveEntity

### DIFF
--- a/world.go
+++ b/world.go
@@ -248,7 +248,8 @@ func (world *World) RemoveEntity(entityId EntityId) {
 	archetype := world.archetypes[entityRecord.archetypeId]
 
 	lastEntityKey := len(archetype.entities) - 1
-	for _, s := range world.storage {
+	for _, componentId := range archetype.Type {
+		s := world.storage[componentId]
 		if s != nil && slices.Contains(archetype.Type, s.getType()) {
 			s.moveLastToKey(archetype.Id, entityRecord.key)
 		}


### PR DESCRIPTION
Use the archetype's components instead of the whole storages in RemoveEntity, to loop on each components to remove. This method got really slower after the Tag feature, because the slice of storages is now bigger (2048 instead of 256).